### PR TITLE
Don't double up dollar signs

### DIFF
--- a/databend_sqlalchemy/connector.py
+++ b/databend_sqlalchemy/connector.py
@@ -38,7 +38,7 @@ class ParamEscaper:
         if isinstance(item, bytes):
             item = item.decode("utf-8")
         return "'{}'".format(
-            item.replace("\\", "\\\\").replace("'", "\\'").replace("$", "$$").replace("%", "%%")
+            item.replace("\\", "\\\\").replace("'", "\\'").replace("%", "%%")
         )
 
     def escape_item(self, item):


### PR DESCRIPTION
I can't find a place where we need to replace $ with $$, but I can find many instances where I just want a single $ and it is currently being doubled and stored incorrectly.