### PR TITLE
Adjust default sequence_step_size

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ ban-relative-imports = True
 inline-quotes = "
 
 [tool:pytest]
-addopts= --tb native -n4 -v -r fxX --maxfail=25 -p no:warnings
+addopts= --tb native -n1 -v -r fxX --maxfail=25 -p no:warnings
 python_files=tests/*test_*.py
 # python_functions=test_round_trip_same_named_column
 # log_level=DEBUG

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,12 +14,13 @@ if version.parse(sqlalchemy.__version__) >= version.parse('2.0.0'):
     from sqlalchemy import event, text
     from sqlalchemy import Engine
 
-
     @event.listens_for(Engine, "connect")
     def receive_engine_connect(conn, r):
         cur = conn.cursor()
         cur.execute('SET global format_null_as_str = 0')
         cur.execute('SET global enable_geo_create_table = 1')
+        try:
+            cur.execute("SET global sequence_step_size = 1")
+        except:
+            pass # don't fail when this setting doesn't exist
         cur.close()
-
-


### PR DESCRIPTION
This sets the sequence_step_size to 1 as the default is 65536, but this may be removed in https://github.com/databendlabs/databend/pull/18659, so protect against that. Tests may also need to be reviewed after that PR, but this will make tests pass for now.